### PR TITLE
Modified title number　タイトル番号の修正

### DIFF
--- a/docs/xamarin-forms/creating-mobile-apps-xamarin-forms/index.md
+++ b/docs/xamarin-forms/creating-mobile-apps-xamarin-forms/index.md
@@ -20,7 +20,7 @@ ms.lasthandoff: 04/04/2018
 これは、*初版*27 のチャプターがあり、Xamarin.Forms をカバー&nbsp;2.x アニメーション、MVVM、トリガー、動作、カスタム レイアウト、カスタムのレンダラーでいっそうなどです。
 28 章も現在オンライン以下に示す個々 のチャプター間できます。
 
-## <a name="download-ebook-for-free"></a>電子を無料でダウンロードします。
+## <a name="download-ebook-for-free"></a>電子書籍を無料でダウンロードします。
 
 Microsoft Virtual Academy から、優先される電子形式をダウンロードします。
 
@@ -38,197 +38,197 @@ Microsoft Virtual Academy から、優先される電子形式をダウンロー
 
 オンライン[章の概要](summaries/index.md)github のサンプルと Api へのリンクをそれぞれの章の内容を説明します。
 
-## <a name="download-individual-chapters"></a>個々 の章をダウンロードします。
+## <a name="download-individual-chapters"></a>個々 の章のダウンロード
 
 <table style="border:0px; box-shadow:0 0px 0px" cellpadding="0" cellspacing="2" border="0" width="85%">
 <tr style="background:#ecf0f1">
   <td style="border:0px;">
-    <h4>第 1 章します。 Xamarin.Forms 調整がどのようにしますか。</h4>
+    <h4>第 1 章 Xamarin.Forms 調整がどのようにしますか。</h4>
   </td>
   <td style="border:0px;" align="right"><a href="https://download.xamarin.com/developer/xamarin-forms-book/XamarinFormsBook-Ch01-Apr2016.pdf">PDF をダウンロードします。</a> </td>
   <td style="border:0px;" align="right"><a href="summaries/chapter01.md">まとめ</a></td>
 </tr>
 <tr style="background:#f8f9fa">
   <td style="border:0px;">
-    <h4>第 2 章します。 アプリの構造</h4>
+    <h4>第 2 章 アプリの構造</h4>
   </td>
   <td style="border:0px;" align="right"><a href="https://download.xamarin.com/developer/xamarin-forms-book/XamarinFormsBook-Ch02-Apr2016.pdf">PDF をダウンロードします。</a> </td>
   <td style="border:0px;" align="right"><a href="summaries/chapter02.md">まとめ</a></td>
 </tr>
 <tr style="background:#ecf0f1">
   <td style="border:0px;">
-    <h4>第 3 章します。 テキストに進む</h4>
+    <h4>第 3 章 テキストに進む</h4>
   </td>
   <td style="border:0px;" align="right"><a href="https://download.xamarin.com/developer/xamarin-forms-book/XamarinFormsBook-Ch03-Apr2016.pdf">PDF をダウンロードします。</a> </td>
   <td style="border:0px;" align="right"><a href="summaries/chapter03.md">まとめ</a></td>
 </tr>
 <tr style="background:#f8f9fa">
   <td style="border:0px;">
-    <h4>第 4 章します。 スタックをスクロール</h4>
+    <h4>第 4 章 スタックをスクロール</h4>
   </td>
   <td style="border:0px;" align="right"><a href="https://download.xamarin.com/developer/xamarin-forms-book/XamarinFormsBook-Ch04-Apr2016.pdf">PDF をダウンロードします。</a> </td>
   <td style="border:0px;" align="right"><a href="summaries/chapter04.md">まとめ</a></td>
 </tr>
 <tr style="background:#ecf0f1">
   <td style="border:0px;">
-    <h4>第 5 章します。 サイズを処理します。</h4>
+    <h4>第 5 章 サイズを処理します。</h4>
   </td>
   <td style="border:0px;" align="right"><a href="https://download.xamarin.com/developer/xamarin-forms-book/XamarinFormsBook-Ch05-Apr2016.pdf">PDF をダウンロードします。</a> </td>
   <td style="border:0px;" align="right"><a href="summaries/chapter05.md">まとめ</a></td>
 </tr>
 <tr style="background:#f8f9fa">
   <td style="border:0px;">
-    <h4>第 6 章します。 ボタンのクリック</h4>
+    <h4>第 6 章 ボタンのクリック</h4>
   </td>
   <td style="border:0px;" align="right"><a href="https://download.xamarin.com/developer/xamarin-forms-book/XamarinFormsBook-Ch06-Apr2016.pdf">PDF をダウンロードします。</a> </td>
   <td style="border:0px;" align="right"><a href="summaries/chapter06.md">まとめ</a></td>
 </tr>
 <tr style="background:#ecf0f1">
   <td style="border:0px;">
-    <h4>第 7 章します。 XAML とします。コード</h4>
+    <h4>第 7 章 XAML とします。コード</h4>
   </td>
   <td style="border:0px;" align="right"><a href="https://download.xamarin.com/developer/xamarin-forms-book/XamarinFormsBook-Ch07-Apr2016.pdf">PDF をダウンロードします。</a> </td>
   <td style="border:0px;" align="right"><a href="summaries/chapter07.md">まとめ</a></td>
 </tr>
 <tr style="background:#f8f9fa">
   <td style="border:0px;">
-    <h4>第 8 章します。 コードと調和で XAML</h4>
+    <h4>第 8 章 コードと調和で XAML</h4>
   </td>
   <td style="border:0px;" align="right"><a href="https://download.xamarin.com/developer/xamarin-forms-book/XamarinFormsBook-Ch08-Apr2016.pdf">PDF をダウンロードします。</a> </td>
   <td style="border:0px;" align="right"><a href="summaries/chapter08.md">まとめ</a></td>
 </tr>
 <tr style="background:#ecf0f1">
   <td style="border:0px;">
-    <h4>章 9 です。 プラットフォーム固有の API 呼び出し</h4>
+    <h4>第9章 プラットフォーム固有の API 呼び出し</h4>
   </td>
   <td style="border:0px;" align="right"><a href="https://download.xamarin.com/developer/xamarin-forms-book/XamarinFormsBook-Ch09-Apr2016.pdf">PDF をダウンロードします。</a> </td>
   <td style="border:0px;" align="right"><a href="summaries/chapter09.md">まとめ</a></td>
 </tr>
 <tr style="background:#f8f9fa">
   <td style="border:0px;">
-    <h4>章 10 です。 XAML マークアップ拡張機能</h4>
+    <h4>第10章 XAML マークアップ拡張機能</h4>
   </td>
   <td style="border:0px;" align="right"><a href="https://download.xamarin.com/developer/xamarin-forms-book/XamarinFormsBook-Ch10-Apr2016.pdf">PDF をダウンロードします。</a> </td>
   <td style="border:0px;" align="right"><a href="summaries/chapter10.md">まとめ</a></td>
 </tr>
 <tr style="background:#ecf0f1">
   <td style="border:0px;">
-    <h4>第 11 章します。 バインド可能なインフラストラクチャ</h4>
+    <h4>第 11 章 バインド可能なインフラストラクチャ</h4>
   </td>
   <td style="border:0px;" align="right"><a href="https://download.xamarin.com/developer/xamarin-forms-book/XamarinFormsBook-Ch11-Apr2016.pdf">PDF をダウンロードします。</a> </td>
   <td style="border:0px;" align="right"><a href="summaries/chapter11.md">まとめ</a></td>
 </tr>
 <tr style="background:#f8f9fa">
   <td style="border:0px;">
-    <h4>章 12 です。 スタイル</h4>
+    <h4>第12章 スタイル</h4>
   </td>
   <td style="border:0px;" align="right"><a href="https://download.xamarin.com/developer/xamarin-forms-book/XamarinFormsBook-Ch12-Apr2016.pdf">PDF をダウンロードします。</a> </td>
   <td style="border:0px;" align="right"><a href="summaries/chapter12.md">まとめ</a></td>
 </tr>
 <tr style="background:#ecf0f1">
   <td style="border:0px;">
-    <h4>第 13 章します。 ビットマップ</h4>
+    <h4>第 13 章 ビットマップ</h4>
   </td>
   <td style="border:0px;" align="right"><a href="https://download.xamarin.com/developer/xamarin-forms-book/XamarinFormsBook-Ch13-Apr2016.pdf">PDF をダウンロードします。</a> </td>
   <td style="border:0px;" align="right"><a href="summaries/chapter13.md">まとめ</a></td>
 </tr>
 <tr style="background:#f8f9fa">
   <td style="border:0px;">
-    <h4>章 14 です。 絶対レイアウト</h4>
+    <h4>第14章 絶対レイアウト</h4>
   </td>
   <td style="border:0px;" align="right"><a href="https://download.xamarin.com/developer/xamarin-forms-book/XamarinFormsBook-Ch14-Apr2016.pdf">PDF をダウンロードします。</a> </td>
   <td style="border:0px;" align="right"><a href="summaries/chapter14.md">まとめ</a></td>
 </tr>
 <tr style="background:#ecf0f1">
   <td style="border:0px;">
-    <h4>第 15 章「します。 対話型のインターフェイス</h4>
+    <h4>第 15 章 対話型のインターフェイス</h4>
   </td>
   <td style="border:0px;" align="right"><a href="https://download.xamarin.com/developer/xamarin-forms-book/XamarinFormsBook-Ch15-Apr2016.pdf">PDF をダウンロードします。</a> </td>
   <td style="border:0px;" align="right"><a href="summaries/chapter15.md">まとめ</a></td>
 </tr>
 <tr style="background:#f8f9fa">
   <td style="border:0px;">
-    <h4>章 16。 データ バインディング</h4>
+    <h4>第16章 データ バインディング</h4>
   </td>
   <td style="border:0px;" align="right"><a href="https://download.xamarin.com/developer/xamarin-forms-book/XamarinFormsBook-Ch16-Apr2016.pdf">PDF をダウンロードします。</a> </td>
   <td style="border:0px;" align="right"><a href="summaries/chapter16.md">まとめ</a></td>
 </tr>
 <tr style="background:#ecf0f1">
   <td style="border:0px;">
-    <h4>Chapter 17 です。 マスター グリッド</h4>
+    <h4>第17章 マスター グリッド</h4>
   </td>
   <td style="border:0px;" align="right"><a href="https://download.xamarin.com/developer/xamarin-forms-book/XamarinFormsBook-Ch17-Apr2016.pdf">PDF をダウンロードします。</a> </td>
   <td style="border:0px;" align="right"><a href="summaries/chapter17.md">まとめ</a></td></tr>
 <tr style="background:#f8f9fa">
   <td style="border:0px;">
-    <h4>第 18 章します。 MVVM</h4>
+    <h4>第 18 章 MVVM</h4>
   </td>
   <td style="border:0px;" align="right"><a href="https://download.xamarin.com/developer/xamarin-forms-book/XamarinFormsBook-Ch18-Apr2016.pdf">PDF をダウンロードします。</a> </td>
   <td style="border:0px;" align="right"><a href="summaries/chapter18.md">まとめ</a></td></tr>
 <tr style="background:#ecf0f1">
   <td style="border:0px;">
-    <h4>19 章します。 コレクション ビュー</h4>
+    <h4>第19 章 コレクション ビュー</h4>
   </td>
   <td style="border:0px;" align="right"><a href="https://download.xamarin.com/developer/xamarin-forms-book/XamarinFormsBook-Ch19-Apr2016.pdf">PDF をダウンロードします。</a> </td>
   <td style="border:0px;" align="right"><a href="summaries/chapter19.md">まとめ</a></td></tr>
 <tr style="background:#f8f9fa">
   <td style="border:0px;">
-    <h4>章 20 です。 Async およびファイル I/O</h4>
+    <h4>第20章 Async およびファイル I/O</h4>
   </td>
   <td style="border:0px;" align="right"><a href="https://download.xamarin.com/developer/xamarin-forms-book/XamarinFormsBook-Ch20-Apr2016.pdf">PDF をダウンロードします。</a> </td>
   <td style="border:0px;" align="right"><a href="summaries/chapter20.md">まとめ</a></td></tr>
 <tr style="background:#ecf0f1">
   <td style="border:0px;">
-    <h4>章 21 です。 変換</h4>
+    <h4>第21章 変換</h4>
   </td>
   <td style="border:0px;" align="right"><a href="https://download.xamarin.com/developer/xamarin-forms-book/XamarinFormsBook-Ch21-Apr2016.pdf">PDF をダウンロードします。</a> </td>
   <td style="border:0px;" align="right"><a href="summaries/chapter21.md">まとめ</a></td></tr>
 </tr>
 <tr style="background:#f8f9fa">
   <td style="border:0px;">
-    <h4>章 22 です。 アニメーション</h4>
+    <h4>第22章 アニメーション</h4>
   </td>
   <td style="border:0px;" align="right"><a href="https://download.xamarin.com/developer/xamarin-forms-book/XamarinFormsBook-Ch22-Apr2016.pdf">PDF をダウンロードします。</a> </td>
   <td style="border:0px;" align="right"><a href="summaries/chapter22.md">まとめ</a></td></tr>
 </tr>
 <tr style="background:#ecf0f1">
   <td style="border:0px;">
-    <h4>章 23 です。 トリガーと動作</h4>
+    <h4>第23章 トリガーと動作</h4>
   </td>
   <td style="border:0px;" align="right"><a href="https://download.xamarin.com/developer/xamarin-forms-book/XamarinFormsBook-Ch23-Apr2016.pdf">PDF をダウンロードします。</a> </td>
   <td style="border:0px;" align="right"><a href="summaries/chapter23.md">まとめ</a></td></tr>
 </tr>
 <tr style="background:#f8f9fa">
   <td style="border:0px;">
-    <h4>章 24 です。 ページ ナビゲーション</h4>
+    <h4>第24章 ページ ナビゲーション</h4>
   </td>
   <td style="border:0px;" align="right"><a href="https://download.xamarin.com/developer/xamarin-forms-book/XamarinFormsBook-Ch24-Apr2016.pdf">PDF をダウンロードします。</a> </td>
   <td style="border:0px;" align="right"><a href="summaries/chapter24.md">まとめ</a></td></tr>
 </tr>
 <tr style="background:#ecf0f1">
   <td style="border:0px;">
-    <h4>第 25 章します。 ページの種類</h4>
+    <h4>第 25 章 ページの種類</h4>
   </td>
   <td style="border:0px;" align="right"><a href="https://download.xamarin.com/developer/xamarin-forms-book/XamarinFormsBook-Ch25-Apr2016.pdf">PDF をダウンロードします。</a> </td>
   <td style="border:0px;" align="right"><a href="summaries/chapter25.md">まとめ</a></td></tr>
 </tr>
 <tr style="background:#f8f9fa">
   <td style="border:0px;">
-    <h4>章 26 です。 カスタム レイアウト</h4>
+    <h4>第26章 カスタム レイアウト</h4>
   </td>
   <td style="border:0px;" align="right"><a href="https://download.xamarin.com/developer/xamarin-forms-book/XamarinFormsBook-Ch26-Apr2016.pdf">PDF をダウンロードします。</a> </td>
   <td style="border:0px;" align="right"><a href="summaries/chapter26.md">まとめ</a></td></tr>
 </tr>
 <tr style="background:#ecf0f1">
   <td style="border:0px;">
-    <h4>章 27。 カスタム レンダラー</h4>
+    <h4>第27章 カスタム レンダラー</h4>
   </td>
   <td style="border:0px;" align="right"><a href="https://download.xamarin.com/developer/xamarin-forms-book/XamarinFormsBook-Ch27-Apr2016.pdf">PDF をダウンロードします。</a> </td>
   <td style="border:0px;" align="right"><a href="summaries/chapter27.md">まとめ</a></td></tr>
 </tr>
 <tr style="background:#f8f9fa">
   <td style="border:0px;">
-    <h4>章 28 です。 場所とマップ</h4>
+    <h4>第28章 場所とマップ</h4>
   </td>
   <td style="border:0px;" align="right"><a href="https://download.xamarin.com/developer/xamarin-forms-book/XamarinFormsBook-Ch28-Aug2016.pdf">PDF をダウンロードします。</a> </td>
   <td style="border:0px;" align="right"><a href="summaries/chapter28.md">まとめ</a></td></tr>
@@ -239,5 +239,5 @@ Microsoft Virtual Academy から、優先される電子形式をダウンロー
 
 ## <a name="related-links"></a>関連リンク
 
-- [MS キーを押してブログ](https://blogs.msdn.microsoft.com/microsoft_press/2016/03/31/free-ebook-creating-mobile-apps-with-xamarin-forms/)
+- [Microsoft のブログ](https://blogs.msdn.microsoft.com/microsoft_press/2016/03/31/free-ebook-creating-mobile-apps-with-xamarin-forms/)
 - [最初のエディションのサンプル](https://github.com/xamarin/xamarin-forms-book-samples)

--- a/docs/xamarin-forms/creating-mobile-apps-xamarin-forms/index.md
+++ b/docs/xamarin-forms/creating-mobile-apps-xamarin-forms/index.md
@@ -20,7 +20,7 @@ ms.lasthandoff: 04/04/2018
 これは、*初版*27 のチャプターがあり、Xamarin.Forms をカバー&nbsp;2.x アニメーション、MVVM、トリガー、動作、カスタム レイアウト、カスタムのレンダラーでいっそうなどです。
 28 章も現在オンライン以下に示す個々 のチャプター間できます。
 
-## <a name="download-ebook-for-free"></a>電子書籍を無料でダウンロードします。
+## <a name="download-ebook-for-free"></a>電子書籍を無料でダウンロード
 
 Microsoft Virtual Academy から、優先される電子形式をダウンロードします。
 
@@ -38,7 +38,7 @@ Microsoft Virtual Academy から、優先される電子形式をダウンロー
 
 オンライン[章の概要](summaries/index.md)github のサンプルと Api へのリンクをそれぞれの章の内容を説明します。
 
-## <a name="download-individual-chapters"></a>個々 の章のダウンロード
+## <a name="download-individual-chapters"></a>個々の章のダウンロード
 
 <table style="border:0px; box-shadow:0 0px 0px" cellpadding="0" cellspacing="2" border="0" width="85%">
 <tr style="background:#ecf0f1">


### PR DESCRIPTION
Fixed some misrepresentations in Japanese translation.
日本語での訳で一部誤表記を修正。

Hi,Today I'm fixed some misrepresentations in Japanese translation.
I fixed changed about chapter Number.

Example,[Chapter 1] is the Japanese auto translate [章１します。].
Please review this.

Thank you.