### PR TITLE
Leave in English, fix

### DIFF
--- a/docs/android/deploy-test/building-apps/build-items.md
+++ b/docs/android/deploy-test/building-apps/build-items.md
@@ -59,8 +59,7 @@ Java Android プロジェクトの `assets` フォルダーに含まれるファ
 
 ## <a name="androidlintconfig"></a>AndroidLintConfig
 
-ビルド アクション 'AndroidLintConfig' は、[`$(AndroidLintEnabled)`](~/android/deploy-test/building-apps/build-properties.md#androidlintenabled) プロパティと組み合わせて使用する必要があります。
-プロパティに基づきます)。 このビルド アクションを含むファイルはマージされ、Android の `lint` ツールに渡されます。 これは、どのテストを有効および無効にするかに関する情報を含んだ XML ファイルになります。
+ビルド アクション 'AndroidLintConfig' は、[`$(AndroidLintEnabled)`](~/android/deploy-test/building-apps/build-properties.md#androidlintenabled) プロパティと組み合わせて使用する必要があります。 このビルド アクションを含むファイルはマージされ、Android の `lint` ツールに渡されます。 これは、どのテストを有効および無効にするかに関する情報を含んだ XML ファイルになります。
 
 詳細については、[Lint に関するドキュメント](https://developer.android.com/studio/write/lint)を参照してください。
 
@@ -132,7 +131,7 @@ Android では、複数のアプリケーション バイナリ インターフ�
 
 Xamarin.Android 10.2 で追加されました。
 
-## <a name="content"></a>コンテンツ
+## <a name="content"></a>Content
 
 通常の `Content` ビルド アクションはサポートされていません (コストのかかる可能性がある最初の実行手順を行わずにサポートする方法が見つかっていないからです)。
 

--- a/docs/android/deploy-test/building-apps/build-properties.md
+++ b/docs/android/deploy-test/building-apps/build-properties.md
@@ -771,7 +771,7 @@ Xamarin.Android 7.2 で追加されました。
 
 Xamarin.Android 9.4 で追加されました。
 
-## <a name="configuration"></a>構成
+## <a name="configuration"></a>Configuration
 
 使用するビルド構成 ("Debug" や "Release" など) を指定します。 Configuration プロパティは、ターゲットの動作を決定するその他のプロパティの既定値を決定するために使用されます。 追加の構成は、IDE 内で作成できます。
 

--- a/docs/android/deploy-test/building-apps/build-targets.md
+++ b/docs/android/deploy-test/building-apps/build-targets.md
@@ -18,7 +18,7 @@ ms.locfileid: "91247221"
 
 Xamarin.Android プロジェクトに対して、次のビルド ターゲットが定義されています。
 
-## <a name="build"></a>ビルド
+## <a name="build"></a>Build
 
 プロジェクト内のソース コードとすべての依存関係をビルドします。
 
@@ -61,7 +61,7 @@ aprofutil $(AProfUtilExtraOptions) -s -v -f -p $(AndroidAotProfilerPort) -o "$(A
 
 Xamarin.Android 10.2 で追加されました。
 
-## <a name="install"></a>インストール
+## <a name="install"></a>Install
 
 既定のデバイスまたは仮想デバイスに、Android パッケージを[作成、署名](#signandroidpackage)、およびインストールします。
 
@@ -106,7 +106,7 @@ adb shell am force-stop @PACKAGE_NAME@
 
 Xamarin.Android 10.2 で追加されました。
 
-## <a name="uninstall"></a>アンインストール
+## <a name="uninstall"></a>Uninstall
 
 既定のデバイスまたは仮想デバイスから Android パッケージをアンインストールします。
 


### PR DESCRIPTION
## Leave in English

- Build items, build properties, and build targets should be left in English.

## Fix

- "プロパティに基づきます)。" should be removed.